### PR TITLE
Support for MultiSyncDataCollector from torch rl and additional simulator parameters. 

### DIFF
--- a/routerl/environment/defaults.json
+++ b/routerl/environment/defaults.json
@@ -46,6 +46,7 @@
         "stuck_time" : 600,
         "daily_reseed" : false,
         "use_libsumo": false,
+        "use_sumo_teleport": false,
 
 
         "number_of_paths" : "${path_generation_parameters.number_of_paths}",

--- a/routerl/environment/defaults.json
+++ b/routerl/environment/defaults.json
@@ -45,6 +45,8 @@
         "sumo_type" : "sumo",
         "stuck_time" : 600,
         "daily_reseed" : false,
+        "use_libsumo": false,
+
 
         "number_of_paths" : "${path_generation_parameters.number_of_paths}",
         "plots_folder": "${plotter_parameters.plots_folder}",

--- a/routerl/environment/defaults.json
+++ b/routerl/environment/defaults.json
@@ -79,6 +79,7 @@
         "phase_names" : [
             "Human learning", 
             "Mutation - Machine learning"
-        ]
+        ],
+        "clear_records" : true
     }
 }

--- a/routerl/environment/environment.py
+++ b/routerl/environment/environment.py
@@ -968,7 +968,7 @@ class TrafficEnvironment(AECEnv):
     ##########################################
 
     def multisync_env_factories(self, env_wrapper, count: int = 0) -> list:
-        """ Creates array of factories that create environments identical to this one. Intended to be used with MultiSyncDataCollector from torchrl.
+        """ Creates array of factories that create environments identical to this one. Intended to be used with MultiSyncDataCollector from torchrl. It is assumed that each episode is one day long and human do not learn.
             
             Args:
                 env_wrapper (Callable): Callable used for wrapping the environment. Should take ``env`` as an argument and return wrapped ``env``. Put all PettingZoo wrappers inside it.

--- a/routerl/environment/environment.py
+++ b/routerl/environment/environment.py
@@ -147,6 +147,8 @@ class TrafficEnvironment(AECEnv):
             
             - use_libsumo (bool, default=False):
                 Whether to use libsumo instead of TraCI. Avoid using both ``libsumo=True`` and ``sumo_type=sumo-gui`` at the same time. Visit https://sumo.dlr.de/docs/Libsumo.html for more insight.
+            - use_sumo_teleport (bool, default=False):
+                If set to ``True`` teleport logic will be handled by SUMO. Otherwise custom python logic will be used.
 
         - path_generation_parameters (dict, optional):
             Path generation settings.

--- a/routerl/environment/environment.py
+++ b/routerl/environment/environment.py
@@ -6,6 +6,8 @@ PettingZoo environment for optimal route choice using SUMO simulator.
 import glob
 import os
 
+from types import new_class
+from multiprocessing import Manager
 from concurrent.futures import ThreadPoolExecutor
 from copy import copy
 from copy import deepcopy as dc
@@ -60,6 +62,8 @@ class TrafficEnvironment(AECEnv):
             Used only for HumanAgent creation and free flow time retrieval.
         generate_asgn_data (bool):
             Generate additional SUMO_output files (per-timestep departures and snapshots).
+        agents (list | None):
+            Agents used in the environment. If set to ``None`` the agents will be generated or read from files. Defaults to None. 
         **kwargs (dict, optional): 
             User-defined parameter overrides. These override default values 
             from ``defaults.json`` and allow experiment configuration.
@@ -316,9 +320,11 @@ class TrafficEnvironment(AECEnv):
                  save_detectors_info: bool = False,
                  action_masks: dict = None,
                  generate_asgn_data: bool = False,
+                 agents: list = None,
                  **kwargs) -> None:
 
         super().__init__()
+        self.kwargs = kwargs
         self.render_mode = None
 
         # Read default parameters, update with kwargs
@@ -352,7 +358,7 @@ class TrafficEnvironment(AECEnv):
         self.recorder = Recorder(self.plotter_params)
         self.simulator = SumoSimulator(self.simulation_params, self.path_gen_params, seed, not create_agents, save_detectors_info, generate_asgn_data, self.use_clustered_routes)
 
-        self.all_agents = generate_agents(self.agent_params, self.get_free_flow_times(), create_agents, seed, self.action_masks)
+        self.all_agents = generate_agents(self.agent_params, self.get_free_flow_times(), create_agents, seed) if agents == None else agents
         self.machine_agents = [agent for agent in self.all_agents if agent.kind == kc.TYPE_MACHINE]
         self.human_agents = [agent for agent in self.all_agents if agent.kind == kc.TYPE_HUMAN]
         self.possible_agents = list()
@@ -954,3 +960,117 @@ class TrafficEnvironment(AECEnv):
                                  self.get_free_flow_times())
         else:
             raise ValueError('[MODEL INVALID] Unrecognized observation type: ' + observation_type)
+
+    ##########################################
+    ### support for MultiSyncDataCollector ###
+    ##########################################
+
+    def multisync_env_factories(self, env_wrapper, count: int = 0) -> list:
+        """ Creates array of factories that create environments identical to this one. Intended to be used with MultiSyncDataCollector from torchrl.
+            
+            Args:
+                env_wrapper (Callable): Callable used for wrapping the environment. Should take ``env`` as an argument and return wrapped ``env``. Put all PettingZoo wrappers inside it.
+                count (int): Number of factories to be returned.
+        """
+        if 0 == count:
+            count = os.cpu_count()-1
+        
+        manager = Manager()
+        shared_ns = manager.Namespace()
+        shared_ns.episode = self.day
+        lock = manager.Lock()
+        counter = MultiSyncTrafficEnvironment._EpisodeCounterDescriptor(shared_ns, lock)
+        counter.inject(self, "day", readonly = False)
+        counter.inject(self.simulator, "runs", readonly = True)
+
+        def make_make_env(i):
+            agents      = dc(self.all_agents)
+            seed        = self.seed
+            params      = dc(self.kwargs)
+            sim_params  = params[kc.SIMULATOR]
+            sim_params[kc.USE_LIBSUMO] = True
+            plotter_params = params[kc.PLOTTER]
+            plotter_params[kc.CLEAR_RECORDS] = False
+
+
+            def make_env():
+                env = MultiSyncTrafficEnvironment(
+                    seed            = seed,
+                    create_agents   = False,
+                    create_paths    = False,
+                    agents          = agents,
+                    **params
+                )
+
+                counter.inject(env, "day", readonly = False)
+                counter.inject(env.simulator, "runs", readonly = True)
+
+                env.start()
+                env.human_learning = False
+                return env_wrapper(env)
+            return make_env
+        return [make_make_env(i) for i in range(count)]
+
+
+
+class MultiSyncTrafficEnvironment(TrafficEnvironment):
+    def close(self) -> None:
+        self.stop_simulation()
+
+
+    class _EpisodeCounterDescriptor:
+        """ Shared (across both classes and processes) episode counter. Intended to make episode data consistent across many workers. 
+
+        Args:
+            manager (multiprocessing.Manager): Manager for episode variable.
+            lock (multiprocessing.Lock): Lock associated with the variable. Note: ``manager.Lock()`` is a good candidate.
+            monotone (bool): If set to ``True`` the counter does not allow the value to be decreased.
+        """
+        def __init__(self, manager, lock, monotone: bool = False):
+            with lock:
+                self.value = manager.episode
+            self.manager = manager
+            self.lock = lock
+            self.monotone = monotone
+            self.ro = set()
+            with lock:
+                self.value = manager.episode
+
+        def __get__(self, obj, objtype=None):
+            return self.value
+
+        def __set__(self, obj, new_value):
+            if obj in self.ro:
+                return
+
+            delta = new_value - self.value
+            if self.monotone and delta < 0:
+                return
+
+            with self.lock:
+                self.manager.episode += delta
+                self.value = self.manager.episode
+
+        def inject(self, obj, field_name, readonly: bool = True) -> None:
+            """ Inject a shared episode counter into object. 
+
+            Args:
+                obj (Object): Object the counter will be injected into.
+                field_name (str): Name of the field to be shadowed by the injected counter.
+                readonly (bool): If set to ``True``, then counter value cannot be changed from ``obj``. 
+            Returns:
+                None
+            """
+
+            old_cls = obj.__class__
+            new_cls = new_class(
+                "_CounterInjected" + old_cls.__name__.replace("_", ""),
+                (old_cls,),
+                kwds=None,
+                exec_body = lambda ns: ns.update ({ field_name: self }),
+            )
+
+            obj.__class__ = new_cls
+            if readonly:
+                self.ro.add(obj)
+

--- a/routerl/environment/environment.py
+++ b/routerl/environment/environment.py
@@ -360,7 +360,7 @@ class TrafficEnvironment(AECEnv):
         self.recorder = Recorder(self.plotter_params)
         self.simulator = SumoSimulator(self.simulation_params, self.path_gen_params, seed, not create_agents, save_detectors_info, generate_asgn_data, self.use_clustered_routes)
 
-        self.all_agents = generate_agents(self.agent_params, self.get_free_flow_times(), create_agents, seed) if agents == None else agents
+        self.all_agents = generate_agents(self.agent_params, self.get_free_flow_times(), create_agents, seed, self.action_masks) if agents == None else agents
         self.machine_agents = [agent for agent in self.all_agents if agent.kind == kc.TYPE_MACHINE]
         self.human_agents = [agent for agent in self.all_agents if agent.kind == kc.TYPE_HUMAN]
         self.possible_agents = list()

--- a/routerl/environment/environment.py
+++ b/routerl/environment/environment.py
@@ -140,6 +140,9 @@ class TrafficEnvironment(AECEnv):
                 
             - daily_reseed (bool, default=False):
                 Whether to change SUMO seed in each reset. If ``False``, the seed will remain constant throughout the simulation.
+            
+            - use_libsumo (bool, default=False):
+                Whether to use libsumo instead of TraCI. Avoid using both ``libsumo=True`` and ``sumo_type=sumo-gui`` at the same time. Visit https://sumo.dlr.de/docs/Libsumo.html for more insight.
 
         - path_generation_parameters (dict, optional):
             Path generation settings.

--- a/routerl/environment/simulator.py
+++ b/routerl/environment/simulator.py
@@ -8,7 +8,6 @@ import janux as jx
 import logging
 import random
 import pandas as pd
-#import traci
 
 from concurrent.futures import ProcessPoolExecutor, as_completed
 

--- a/routerl/environment/simulator.py
+++ b/routerl/environment/simulator.py
@@ -57,6 +57,7 @@ class SumoSimulator():
         self.stuck_time          = params[kc.STUCK_TIME]
         self.daily_reseed        = params[kc.DAILY_RESEED]
         self.use_libsumo         = params[kc.USE_LIBSUMO]
+        self.use_sumo_teleport   = params[kc.USE_SUMO_TELEPORT]
 
         self.experiment_id = 0 # for generate_asgn_data, overwritten through env.unwrapped.simulator.experiment_id = ... in URB scripts
         self.generate_asgn_data = generate_asgn_data
@@ -351,6 +352,7 @@ class SumoSimulator():
         combined_sumo_stats_file = os.path.join(self.sumo_save_path,
                                                 f"sumo_stats_{self.runs}.xml")
 
+        time_to_teleport = self.stuck_time if self.use_sumo_teleport else -1
         sumo_cmd = [
             self.sumo_type,
             "--seed",
@@ -362,7 +364,7 @@ class SumoSimulator():
             "--no-step-log",
             "true",
             "--time-to-teleport",
-            "-1",
+            f"{time_to_teleport}",
             "--statistic-output",
             combined_sumo_stats_file,
             "--tripinfo-output",
@@ -415,6 +417,7 @@ class SumoSimulator():
         
         if self.daily_reseed:   self.day_seed = random.randint(0, 1000)
         
+        time_to_teleport = self.stuck_time if self.use_sumo_teleport else -1
         sumo_cmd = [
             "--seed",
             str(self.day_seed),
@@ -425,7 +428,7 @@ class SumoSimulator():
             "--no-step-log",
             "true",
             "--time-to-teleport",
-            "-1",
+            f"{time_to_teleport}",
             "--statistic-output",
             combined_sumo_stats_file,
             "--tripinfo-output",
@@ -483,6 +486,30 @@ class SumoSimulator():
                                          typeID=kind)
         self.waiting_vehicles[str(act_dict[kc.AGENT_ID])] = 0
 
+    
+    def _teleportVehicles(self):
+        if self.use_sumo_teleport:
+            teleported = self.sumo_connection.simulation.getStartingTeleportIDList()
+            for veh_id in teleported:
+                self.sumo_connection.vehicle.remove(veh_id)
+
+            return teleported
+
+        teleported = list()
+        for veh_id in self.waiting_vehicles.copy():
+            if self.sumo_connection.vehicle.getSpeed(veh_id) == 0:
+                self.waiting_vehicles[veh_id] += 1
+                if self.waiting_vehicles[veh_id] > self.stuck_time:
+                    self.sumo_connection.vehicle.remove(veh_id)
+                    logging.info(f"Timestep #{self.timestep}: Teleporting {veh_id} due to being stuck for {self.waiting_vehicles[veh_id]} seconds.")
+                    teleported.append(veh_id)
+                    self.waiting_vehicles.pop(veh_id, None)
+            else:
+                self.waiting_vehicles[veh_id] = 0
+
+        return teleported
+
+
     def step(self) -> tuple:
         """Advances the SUMO simulation by one timestep and retrieves information
         about vehicle arrivals and detector data.
@@ -500,18 +527,7 @@ class SumoSimulator():
         for arr in arrivals:
             self.waiting_vehicles.pop(arr, None)
         
-        # Teleport vehicles that are stuck
-        teleported = list()
-        for veh_id in self.waiting_vehicles.copy():
-            if self.sumo_connection.vehicle.getSpeed(veh_id) == 0:
-                self.waiting_vehicles[veh_id] += 1
-                if self.waiting_vehicles[veh_id] > self.stuck_time:
-                    self.sumo_connection.vehicle.remove(veh_id)
-                    logging.info(f"Timestep #{self.timestep}: Teleporting {veh_id} due to being stuck for {self.waiting_vehicles[veh_id]} seconds.")
-                    teleported.append(veh_id)
-                    self.waiting_vehicles.pop(veh_id, None)
-            else:
-                self.waiting_vehicles[veh_id] = 0
+        teleported = self._teleportVehicles()
                 
         # Advance the simulation by one timestep       
         self.sumo_connection.simulationStep()

--- a/routerl/environment/simulator.py
+++ b/routerl/environment/simulator.py
@@ -8,7 +8,7 @@ import janux as jx
 import logging
 import random
 import pandas as pd
-import traci
+#import traci
 
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
@@ -56,6 +56,7 @@ class SumoSimulator():
         self.simulation_length   = params[kc.SIMULATION_TIMESTEPS]
         self.stuck_time          = params[kc.STUCK_TIME]
         self.daily_reseed        = params[kc.DAILY_RESEED]
+        self.use_libsumo         = params[kc.USE_LIBSUMO]
 
         self.experiment_id = 0 # for generate_asgn_data, overwritten through env.unwrapped.simulator.experiment_id = ... in URB scripts
         self.generate_asgn_data = generate_asgn_data
@@ -367,8 +368,19 @@ class SumoSimulator():
             "--tripinfo-output",
             individual_sumo_stats_file
             ]
-        traci.start(sumo_cmd, label=self.sumo_id)
-        self.sumo_connection = traci.getConnection(self.sumo_id)
+
+        
+        # import libsumo while using traci semantics
+        if self.use_libsumo:
+            import libsumo as traci
+            traci.start(sumo_cmd, label=self.sumo_id)
+            self.sumo_connection = traci
+
+        else:
+            import traci
+            traci.start(sumo_cmd, label=self.sumo_id)
+            self.sumo_connection = traci.getConnection(self.sumo_id)
+
 
     def stop(self) -> None:
         """Stops and closes the SUMO simulation.

--- a/routerl/keychain.py
+++ b/routerl/keychain.py
@@ -50,6 +50,7 @@ class Keychain:
     STUCK_TIME = "stuck_time"
     DAILY_RESEED = "daily_reseed"    
     USE_LIBSUMO = "use_libsumo"
+    USE_SUMO_TELEPORT = "use_sumo_teleport"
 
 
     ### Plotter

--- a/routerl/keychain.py
+++ b/routerl/keychain.py
@@ -48,7 +48,9 @@ class Keychain:
     SUMO_TYPE = "sumo_type"
     SIMULATION_TIMESTEPS = "simulation_timesteps"
     STUCK_TIME = "stuck_time"
-    DAILY_RESEED = "daily_reseed"
+    DAILY_RESEED = "daily_reseed"    
+    USE_LIBSUMO = "use_libsumo"
+
 
     ### Plotter
     RECORDS_FOLDER = "records_folder"

--- a/routerl/keychain.py
+++ b/routerl/keychain.py
@@ -59,6 +59,7 @@ class Keychain:
     PHASES = "phases"
     PHASE_NAMES = "phase_names"
     SMOOTH_BY = "smooth_by"
+    CLEAR_RECORDS = "clear_records"
 
     ### Agent generation
     NUM_AGENTS = "num_agents"

--- a/routerl/services/recorder.py
+++ b/routerl/services/recorder.py
@@ -30,9 +30,10 @@ class Recorder:
         self.detector_folder = make_dir([self.records_folder, kc.DETECTOR_LOGS_FOLDER])
         self.sumo_folder = make_dir([self.records_folder, kc.SUMO_LOGS_FOLDER])
 
-        self._clear_records(self.episodes_folder)
-        self._clear_records(self.detector_folder)
-        self._clear_records(self.sumo_folder)
+        if params.get(kc.CLEAR_RECORDS, True):
+            self._clear_records(self.episodes_folder)
+            self._clear_records(self.detector_folder)
+            self._clear_records(self.sumo_folder)
         
         self.loss_file_path = self._get_txt_file_path(kc.LOSSES_LOG_FILE_NAME)
         logging.info(f"[SUCCESS] Recorder is now here to record!")


### PR DESCRIPTION
### summary

1. **`multisync_env_factories`**
   * A function that returns a list of factories expected by `MultiDataSyncCollector`.
   * Currently assumes each episode lasts one day and humans do not learn. 

2. **`use_libsumo`**
   * simulator parameter
   * Controls whether `libsumo` is used instead of `traci`. 
   * Introduced to make multiprocessing with SUMO feasible, though it also speeds up single-process operations.
   * **Default:** `False` (for reproducibility).

3. **`clear_records`**
   * plotter parameter
   * Recorder clears record folders when set to `True`.
   * Added to prevent multiprocessed environments from wiping out records.
   * **Default:** `True`.

4. **`use_sumo_teleports` (Simulator Parameter)**
   * If `True` sumo keeps track of stuck vehicles instead of python code.
   * In both cases, stuck vehicles are removed.
   * **Default:** `False` (for reproducibility).
  

